### PR TITLE
feat: Add ping support to clients and server

### DIFF
--- a/client.go
+++ b/client.go
@@ -23,6 +23,7 @@ type Client interface {
 	ReadResource(ctx context.Context, req *Request[ReadResourceRequest]) (*Response[ReadResourceResponse], error)
 	ListResourceTemplates(ctx context.Context, req *Request[ListResourceTemplatesRequest]) (*Response[ListResourceTemplatesResponse], error)
 	Completion(ctx context.Context, req *Request[CompletionRequest]) (*Response[CompletionResponse], error)
+	Ping(ctx context.Context, req *Request[PingRequest]) (*Response[PingResponse], error)
 }
 
 type StdioClient struct {
@@ -165,4 +166,8 @@ func (c *StdioClient) ListResourceTemplates(ctx context.Context, request *Reques
 
 func (c *StdioClient) Completion(ctx context.Context, request *Request[CompletionRequest]) (*Response[CompletionResponse], error) {
 	return clientCallUnary[CompletionRequest, CompletionResponse](ctx, c, "completion", request)
+}
+
+func (c *StdioClient) Ping(ctx context.Context, request *Request[PingRequest]) (*Response[PingResponse], error) {
+	return clientCallUnary[PingRequest, PingResponse](ctx, c, "ping", request)
 }

--- a/internal/endtoend/endtoend_test.go
+++ b/internal/endtoend/endtoend_test.go
@@ -60,4 +60,11 @@ func TestEndToEnd(t *testing.T) {
 			t.Fatalf("expected protocol version 1.0.0, got %s", resp.Result.ProtocolVersion)
 		}
 	}
+
+	{
+		_, err := client.Ping(ctx, mcp.NewRequest(&mcp.PingRequest{}))
+		if err != nil {
+			t.Fatalf("failed to ping server: %v", err)
+		}
+	}
 }

--- a/messages.go
+++ b/messages.go
@@ -202,3 +202,9 @@ type CompletionResult struct {
 	HasMore bool     `json:"hasMore"`
 	Total   int      `json:"total"`
 }
+
+type PingRequest struct {
+}
+
+type PingResponse struct {
+}

--- a/server.go
+++ b/server.go
@@ -21,6 +21,7 @@ type Server interface {
 	ReadResource(ctx context.Context, req *Request[ReadResourceRequest]) (*Response[ReadResourceResponse], error)
 	ListResourceTemplates(ctx context.Context, req *Request[ListResourceTemplatesRequest]) (*Response[ListResourceTemplatesResponse], error)
 	Completion(ctx context.Context, req *Request[CompletionRequest]) (*Response[CompletionResponse], error)
+	Ping(ctx context.Context, req *Request[PingRequest]) (*Response[PingResponse], error)
 }
 
 type UnimplementedServer struct{}
@@ -59,6 +60,10 @@ func (s *UnimplementedServer) ListResourceTemplates(ctx context.Context, req *Re
 
 func (s *UnimplementedServer) Completion(ctx context.Context, req *Request[CompletionRequest]) (*Response[CompletionResponse], error) {
 	return nil, fmt.Errorf("unimplemented")
+}
+
+func (s *UnimplementedServer) Ping(ctx context.Context, req *Request[PingRequest]) (*Response[PingResponse], error) {
+	return NewResponse(&PingResponse{}), nil
 }
 
 func process[T, V any](ctx context.Context, cfg *serverConfig, msg jsonrpc.Request, params *T, method func(ctx context.Context, req *Request[T]) (*Response[V], error)) (any, error) {
@@ -168,6 +173,9 @@ func (s StdioServer) Listen(ctx context.Context, r io.Reader, w io.Writer) error
 		case "resources/templates/list":
 			params := &ListResourceTemplatesRequest{}
 			result, err = process(ctx, cfg, msg, params, srv.ListResourceTemplates)
+		case "ping":
+			params := &PingRequest{}
+			result, err = process(ctx, cfg, msg, params, srv.Ping)
 		default:
 			if msg.ID == "" {
 				// Ignore notifications


### PR DESCRIPTION
Unlike other methods, the unimplemented server has a default implementation for the ping method.

Fixes https://github.com/riza-io/mcp-go/issues/6