### PR TITLE
feat: Implement the `logging/setLevel` method

### DIFF
--- a/client.go
+++ b/client.go
@@ -24,6 +24,7 @@ type Client interface {
 	ListResourceTemplates(ctx context.Context, req *Request[ListResourceTemplatesRequest]) (*Response[ListResourceTemplatesResponse], error)
 	Completion(ctx context.Context, req *Request[CompletionRequest]) (*Response[CompletionResponse], error)
 	Ping(ctx context.Context, req *Request[PingRequest]) (*Response[PingResponse], error)
+	SetLogLevel(ctx context.Context, req *Request[SetLogLevelRequest]) (*Response[SetLogLevelResponse], error)
 }
 
 type StdioClient struct {
@@ -170,4 +171,8 @@ func (c *StdioClient) Completion(ctx context.Context, request *Request[Completio
 
 func (c *StdioClient) Ping(ctx context.Context, request *Request[PingRequest]) (*Response[PingResponse], error) {
 	return clientCallUnary[PingRequest, PingResponse](ctx, c, "ping", request)
+}
+
+func (c *StdioClient) SetLogLevel(ctx context.Context, request *Request[SetLogLevelRequest]) (*Response[SetLogLevelResponse], error) {
+	return clientCallUnary[SetLogLevelRequest, SetLogLevelResponse](ctx, c, "logging/setLevel", request)
 }

--- a/internal/endtoend/endtoend_test.go
+++ b/internal/endtoend/endtoend_test.go
@@ -18,6 +18,10 @@ func (s *server) Initialize(ctx context.Context, req *mcp.Request[mcp.Initialize
 	}), nil
 }
 
+func (s *server) SetLogLevel(ctx context.Context, req *mcp.Request[mcp.SetLogLevelRequest]) (*mcp.Response[mcp.SetLogLevelResponse], error) {
+	return mcp.NewResponse(&mcp.SetLogLevelResponse{}), nil
+}
+
 func TestEndToEnd(t *testing.T) {
 	ctx := context.Background()
 
@@ -49,7 +53,7 @@ func TestEndToEnd(t *testing.T) {
 		}
 	}()
 
-	{
+	t.Run("initialize", func(t *testing.T) {
 		resp, err := client.Initialize(ctx, mcp.NewRequest(&mcp.InitializeRequest{
 			ProtocolVersion: "1.0.0",
 		}))
@@ -59,12 +63,21 @@ func TestEndToEnd(t *testing.T) {
 		if resp.Result.ProtocolVersion != "1.0.0" {
 			t.Fatalf("expected protocol version 1.0.0, got %s", resp.Result.ProtocolVersion)
 		}
-	}
+	})
 
-	{
+	t.Run("ping", func(t *testing.T) {
 		_, err := client.Ping(ctx, mcp.NewRequest(&mcp.PingRequest{}))
 		if err != nil {
 			t.Fatalf("failed to ping server: %v", err)
 		}
-	}
+	})
+
+	t.Run("set log level", func(t *testing.T) {
+		_, err := client.SetLogLevel(ctx, mcp.NewRequest(&mcp.SetLogLevelRequest{
+			Level: mcp.LevelInfo,
+		}))
+		if err != nil {
+			t.Fatalf("failed to set log level: %v", err)
+		}
+	})
 }

--- a/messages.go
+++ b/messages.go
@@ -208,3 +208,23 @@ type PingRequest struct {
 
 type PingResponse struct {
 }
+
+type Level string
+
+const (
+	LevelDebug     Level = "debug"
+	LevelAlert     Level = "alert"
+	LevelCritical  Level = "critical"
+	LevelEmergency Level = "emergency"
+	LevelError     Level = "error"
+	LevelInfo      Level = "info"
+	LevelNotice    Level = "notice"
+	LevelWarning   Level = "warning"
+)
+
+type SetLogLevelRequest struct {
+	Level Level `json:"level"`
+}
+
+type SetLogLevelResponse struct {
+}

--- a/server.go
+++ b/server.go
@@ -22,6 +22,7 @@ type Server interface {
 	ListResourceTemplates(ctx context.Context, req *Request[ListResourceTemplatesRequest]) (*Response[ListResourceTemplatesResponse], error)
 	Completion(ctx context.Context, req *Request[CompletionRequest]) (*Response[CompletionResponse], error)
 	Ping(ctx context.Context, req *Request[PingRequest]) (*Response[PingResponse], error)
+	SetLogLevel(ctx context.Context, req *Request[SetLogLevelRequest]) (*Response[SetLogLevelResponse], error)
 }
 
 type UnimplementedServer struct{}
@@ -64,6 +65,10 @@ func (s *UnimplementedServer) Completion(ctx context.Context, req *Request[Compl
 
 func (s *UnimplementedServer) Ping(ctx context.Context, req *Request[PingRequest]) (*Response[PingResponse], error) {
 	return NewResponse(&PingResponse{}), nil
+}
+
+func (s *UnimplementedServer) SetLogLevel(ctx context.Context, req *Request[SetLogLevelRequest]) (*Response[SetLogLevelResponse], error) {
+	return nil, fmt.Errorf("unimplemented")
 }
 
 func process[T, V any](ctx context.Context, cfg *serverConfig, msg jsonrpc.Request, params *T, method func(ctx context.Context, req *Request[T]) (*Response[V], error)) (any, error) {
@@ -191,6 +196,9 @@ func (s StdioServer) processMessage(ctx context.Context, line []byte) ([]byte, e
 	case "ping":
 		params := &PingRequest{}
 		result, err = process(ctx, cfg, msg, params, srv.Ping)
+	case "logging/setLevel":
+		params := &SetLogLevelRequest{}
+		result, err = process(ctx, cfg, msg, params, srv.SetLogLevel)
 	default:
 		if msg.ID == "" {
 			// Ignore notifications


### PR DESCRIPTION
We don't support notifications yet, so we can't actually emit logs yet.